### PR TITLE
Macro to generate Serialize impl for trait objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,9 @@ extern crate serde_derive;
 #[cfg(test)]
 extern crate serde_json;
 
+#[macro_use]
+mod macros;
+
 mod any;
 mod de;
 mod error;
@@ -107,4 +110,8 @@ mod ser;
 
 pub use de::{deserialize, Deserializer};
 pub use error::Error;
-pub use ser::{Serialize, Serializer};
+pub use ser::{serialize, Serialize, Serializer};
+
+// Not public API.
+#[doc(hidden)]
+pub mod private;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,148 @@
+/// Implement `serde::Serialize` for a trait object that has
+/// `erased_serde::Serialize` as a supertrait.
+///
+/// ```
+/// #[macro_use]
+/// extern crate erased_serde;
+///
+/// trait Event: erased_serde::Serialize {
+///     /* ... */
+/// }
+///
+/// serialize_trait_object!(Event);
+/// #
+/// # fn main() {}
+/// ```
+///
+/// The macro supports traits that have type parameters and/or `where` clauses.
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate erased_serde;
+/// #
+/// trait Difficult<T>: erased_serde::Serialize where T: Copy {
+///     /* ... */
+/// }
+///
+/// serialize_trait_object!(<T> Difficult<T> where T: Copy);
+/// #
+/// # fn main() {}
+/// ```
+#[macro_export]
+macro_rules! serialize_trait_object {
+    ($($path:tt)+) => {
+        __internal_serialize_trait_object!(begin $($path)+);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_serialize_trait_object {
+    // Invocation started with `<`, parse generics.
+    (begin < $($rest:tt)*) => {
+        __internal_serialize_trait_object!(generics () () $($rest)*);
+    };
+
+    // Invocation did not start with `<`.
+    (begin $first:tt $($rest:tt)*) => {
+        __internal_serialize_trait_object!(path () ($first) $($rest)*);
+    };
+
+    // End of generics.
+    (generics ($($generics:tt)*) () > $($rest:tt)*) => {
+        __internal_serialize_trait_object!(path ($($generics)*) () $($rest)*);
+    };
+
+    // Generics open bracket.
+    (generics ($($generics:tt)*) ($($brackets:tt)*) < $($rest:tt)*) => {
+        __internal_serialize_trait_object!(generics ($($generics)* <) ($($brackets)* <) $($rest)*);
+    };
+
+    // Generics close bracket.
+    (generics ($($generics:tt)*) (< $($brackets:tt)*) > $($rest:tt)*) => {
+        __internal_serialize_trait_object!(generics ($($generics)* >) ($($brackets)*) $($rest)*);
+    };
+
+    // Token inside of generics.
+    (generics ($($generics:tt)*) ($($brackets:tt)*) $first:tt $($rest:tt)*) => {
+        __internal_serialize_trait_object!(generics ($($generics)* $first) ($($brackets)*) $($rest)*);
+    };
+
+    // End with `where` clause.
+    (path ($($generics:tt)*) ($($path:tt)*) where $($rest:tt)*) => {
+        __internal_serialize_trait_object!(sendsync ($($generics)*) ($($path)*) ($($rest)*));
+    };
+
+    // End without `where` clause.
+    (path ($($generics:tt)*) ($($path:tt)*)) => {
+        __internal_serialize_trait_object!(sendsync ($($generics)*) ($($path)*) ());
+    };
+
+    // Token inside of path.
+    (path ($($generics:tt)*) ($($path:tt)*) $first:tt $($rest:tt)*) => {
+        __internal_serialize_trait_object!(path ($($generics)*) ($($path)* $first) $($rest)*);
+    };
+
+    // Expand into four impls.
+    (sendsync ($($generics:tt)*) ($($path:tt)*) ($($bound:tt)*)) => {
+        __internal_serialize_trait_object!(impl ($($generics)*) ($($path)*) ($($bound)*));
+        __internal_serialize_trait_object!(impl ($($generics)*) ($($path)* + $crate::private::Send) ($($bound)*));
+        __internal_serialize_trait_object!(impl ($($generics)*) ($($path)* + $crate::private::Sync) ($($bound)*));
+        __internal_serialize_trait_object!(impl ($($generics)*) ($($path)* + $crate::private::Send + $crate::private::Sync) ($($bound)*));
+    };
+
+    // The impl.
+    (impl ($($generics:tt)*) ($($path:tt)*) ($($bound:tt)*)) => {
+        impl<'erased, $($generics)*> $crate::private::serde::Serialize for $($path)* + 'erased where $($bound)* {
+            fn serialize<S>(&self, serializer: S) -> $crate::private::Result<S::Ok, S::Error> where S: $crate::private::serde::Serializer {
+                $crate::serialize(self, serializer)
+            }
+        }
+    };
+}
+
+// TEST ////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use serde;
+    use Serialize;
+
+    fn assert_serialize<T: ?Sized + serde::Serialize>() {}
+
+    #[test]
+    fn test_plain() {
+        trait Trait: Serialize {}
+
+        serialize_trait_object!(Trait);
+        assert_serialize::<Trait>();
+        assert_serialize::<Trait + Send>();
+    }
+
+    #[test]
+    fn test_type_parameter() {
+        trait Trait<T>: Serialize {}
+
+        serialize_trait_object!(<T> Trait<T>);
+        assert_serialize::<Trait<u32>>();
+        assert_serialize::<Trait<u32> + Send>();
+    }
+
+    #[test]
+    fn test_generic_bound() {
+        trait Trait<T: PartialEq<T>, U>: Serialize {}
+
+        serialize_trait_object!(<T: PartialEq<T>, U> Trait<T, U>);
+        assert_serialize::<Trait<u32, ()>>();
+        assert_serialize::<Trait<u32, ()> + Send>();
+    }
+
+    #[test]
+    fn test_where_clause() {
+        trait Trait<T>: Serialize where T: Clone {}
+
+        serialize_trait_object!(<T> Trait<T> where T: Clone);
+        assert_serialize::<Trait<u32>>();
+        assert_serialize::<Trait<u32> + Send>();
+    }
+}

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,0 +1,5 @@
+//! Not public API. Used as `$crate::export` by macros.
+
+pub extern crate serde;
+pub use std::marker::{Send, Sync};
+pub use std::result::Result;


### PR DESCRIPTION
```rust
extern crate serde;

#[macro_use]
extern crate erased_serde;

trait Event: erased_serde::Serialize {}

serialize_trait_object!(Event);

fn main() {
    fn assert_serialize<T: ?Sized + serde::Serialize>() {}
    assert_serialize::<Event>();
}
```