### PR TITLE
Add support for 128bit numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["serde", "erasure"]
 include = ["Cargo.toml", "src/**/*.rs", "LICENSE-*"]
 
 [dependencies]
-serde = "1.0"
+serde = "1.0.63"
 
 [dev-dependencies]
 serde_cbor = "0.8"

--- a/src/de.rs
+++ b/src/de.rs
@@ -98,6 +98,14 @@ pub trait Deserializer<'de> {
     fn erased_deserialize_i16(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_i32(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_i64(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
+    serde_if_integer128! {
+        fn erased_deserialize_i128(&mut self, &mut Visitor<'de>) -> Result<Out, Error> {
+            Err(<Error as serde::de::Error>::custom("erased I128 is not supported"))
+        }
+        fn erased_deserialize_u128(&mut self, &mut Visitor<'de>) -> Result<Out, Error> {
+            Err(<Error as serde::de::Error>::custom("erased U128 is not supported"))
+        }
+    }
     fn erased_deserialize_f32(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_f64(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_char(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
@@ -131,6 +139,14 @@ pub trait Visitor<'de> {
     fn erased_visit_u16(&mut self, u16) -> Result<Out, Error>;
     fn erased_visit_u32(&mut self, u32) -> Result<Out, Error>;
     fn erased_visit_u64(&mut self, u64) -> Result<Out, Error>;
+    serde_if_integer128! {
+        fn erased_visit_i128(&mut self, i128) -> Result<Out, Error> {
+            Err(<Error as serde::de::Error>::custom("erased U128 is not supported"))
+        }
+        fn erased_visit_u128(&mut self, u128) -> Result<Out, Error> {
+            Err(<Error as serde::de::Error>::custom("erased I128 is not supported"))
+        }
+    }
     fn erased_visit_f32(&mut self, f32) -> Result<Out, Error>;
     fn erased_visit_f64(&mut self, f64) -> Result<Out, Error>;
     fn erased_visit_char(&mut self, char) -> Result<Out, Error>;
@@ -326,6 +342,14 @@ impl<'de, T> Deserializer<'de> for erase::Deserializer<T> where T: serde::Deseri
     }
     fn erased_deserialize_i64(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
         self.take().deserialize_i64(visitor).map_err(erase)
+    }
+    serde_if_integer128! {
+        fn erased_deserialize_u128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
+            self.take().deserialize_u128(visitor).map_err(erase)
+        }
+        fn erased_deserialize_i128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
+            self.take().deserialize_i128(visitor).map_err(erase)
+        }
     }
     fn erased_deserialize_f32(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
         self.take().deserialize_f32(visitor).map_err(erase)
@@ -572,6 +596,16 @@ macro_rules! impl_deserializer_for_trait_object {
                 let mut erased = erase::Visitor { state: Some(visitor) };
                 self.erased_deserialize_i64(&mut erased).map(Out::take)
             }
+            serde_if_integer128! {
+                fn deserialize_i128<V>($($mut)* self, visitor: V) -> Result<V::Value, Error> where V: serde::de::Visitor<'de> {
+                    let mut erased = erase::Visitor { state: Some(visitor) };
+                    self.erased_deserialize_i128(&mut erased).map(Out::take)
+                }
+                fn deserialize_u128<V>($($mut)* self, visitor: V) -> Result<V::Value, Error> where V: serde::de::Visitor<'de> {
+                    let mut erased = erase::Visitor { state: Some(visitor) };
+                    self.erased_deserialize_u128(&mut erased).map(Out::take)
+                }
+            }
             fn deserialize_f32<V>($($mut)* self, visitor: V) -> Result<V::Value, Error> where V: serde::de::Visitor<'de> {
                 let mut erased = erase::Visitor { state: Some(visitor) };
                 self.erased_deserialize_f32(&mut erased).map(Out::take)
@@ -695,6 +729,14 @@ impl<'de, 'a> serde::de::Visitor<'de> for &'a mut Visitor<'de> {
     }
     fn visit_u64<E>(self, v: u64) -> Result<Out, E> where E: serde::de::Error {
         self.erased_visit_u64(v).map_err(unerase)
+    }
+    serde_if_integer128! {
+        fn visit_i128<E>(self, v: i128) -> Result<Out, E> where E: serde::de::Error {
+            self.erased_visit_i128(v).map_err(unerase)
+        }
+        fn visit_u128<E>(self, v: u128) -> Result<Out, E> where E: serde::de::Error {
+            self.erased_visit_u128(v).map_err(unerase)
+        }
     }
     fn visit_f32<E>(self, v: f32) -> Result<Out, E> where E: serde::de::Error {
         self.erased_visit_f32(v).map_err(unerase)
@@ -847,6 +889,14 @@ macro_rules! deref_erased_deserializer {
             }
             fn erased_deserialize_i64(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
                 (**self).erased_deserialize_i64(visitor)
+            }
+            serde_if_integer128! {
+                fn erased_deserialize_i128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
+                    (**self).erased_deserialize_i128(visitor)
+                }
+                fn erased_deserialize_u128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
+                    (**self).erased_deserialize_u128(visitor)
+                }
             }
             fn erased_deserialize_f32(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
                 (**self).erased_deserialize_f32(visitor)

--- a/src/de.rs
+++ b/src/de.rs
@@ -99,12 +99,8 @@ pub trait Deserializer<'de> {
     fn erased_deserialize_i32(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_i64(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     serde_if_integer128! {
-        fn erased_deserialize_i128(&mut self, &mut Visitor<'de>) -> Result<Out, Error> {
-            Err(<Error as serde::de::Error>::custom("erased I128 is not supported"))
-        }
-        fn erased_deserialize_u128(&mut self, &mut Visitor<'de>) -> Result<Out, Error> {
-            Err(<Error as serde::de::Error>::custom("erased U128 is not supported"))
-        }
+        fn erased_deserialize_i128(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
+        fn erased_deserialize_u128(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     }
     fn erased_deserialize_f32(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
     fn erased_deserialize_f64(&mut self, &mut Visitor<'de>) -> Result<Out, Error>;
@@ -140,12 +136,8 @@ pub trait Visitor<'de> {
     fn erased_visit_u32(&mut self, u32) -> Result<Out, Error>;
     fn erased_visit_u64(&mut self, u64) -> Result<Out, Error>;
     serde_if_integer128! {
-        fn erased_visit_i128(&mut self, i128) -> Result<Out, Error> {
-            Err(<Error as serde::de::Error>::custom("erased U128 is not supported"))
-        }
-        fn erased_visit_u128(&mut self, u128) -> Result<Out, Error> {
-            Err(<Error as serde::de::Error>::custom("erased I128 is not supported"))
-        }
+        fn erased_visit_i128(&mut self, i128) -> Result<Out, Error>;
+        fn erased_visit_u128(&mut self, u128) -> Result<Out, Error>;
     }
     fn erased_visit_f32(&mut self, f32) -> Result<Out, Error>;
     fn erased_visit_f64(&mut self, f64) -> Result<Out, Error>;
@@ -344,11 +336,11 @@ impl<'de, T> Deserializer<'de> for erase::Deserializer<T> where T: serde::Deseri
         self.take().deserialize_i64(visitor).map_err(erase)
     }
     serde_if_integer128! {
-        fn erased_deserialize_u128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
-            self.take().deserialize_u128(visitor).map_err(erase)
-        }
         fn erased_deserialize_i128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
             self.take().deserialize_i128(visitor).map_err(erase)
+        }
+        fn erased_deserialize_u128(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
+            self.take().deserialize_u128(visitor).map_err(erase)
         }
     }
     fn erased_deserialize_f32(&mut self, visitor: &mut Visitor<'de>) -> Result<Out, Error> {
@@ -443,6 +435,14 @@ impl<'de, T> Visitor<'de> for erase::Visitor<T> where T: serde::de::Visitor<'de>
     }
     fn erased_visit_u64(&mut self, v: u64) -> Result<Out, Error> {
         self.take().visit_u64(v).map(Out::new)
+    }
+    serde_if_integer128! {
+        fn erased_visit_i128(&mut self, v: i128) -> Result<Out, Error> {
+            self.take().visit_i128(v).map(Out::new)
+        }
+        fn erased_visit_u128(&mut self, v: u128) -> Result<Out, Error> {
+            self.take().visit_u128(v).map(Out::new)
+        }
     }
     fn erased_visit_f32(&mut self, v: f32) -> Result<Out, Error> {
         self.take().visit_f32(v).map(Out::new)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@
 
 #![cfg_attr(feature = "unstable-debug", feature(core_intrinsics))]
 
+#[macro_use]
 extern crate serde;
 
 #[cfg(test)]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -112,6 +112,15 @@ pub trait Serializer {
     fn erased_serialize_u16(&mut self, u16) -> Result<Ok, Error>;
     fn erased_serialize_u32(&mut self, u32) -> Result<Ok, Error>;
     fn erased_serialize_u64(&mut self, u64) -> Result<Ok, Error>;
+    serde_if_integer128! {
+        fn erased_serialize_i128(&mut self, i128) -> Result<Ok, Error> {
+            Err(<Error as serde::ser::Error>::custom("erased I128 is not supported"))
+        }
+
+        fn erased_serialize_u128(&mut self, u128) -> Result<Ok, Error> {
+            Err(<Error as serde::ser::Error>::custom("erased U128 is not supported"))
+        }
+    }
     fn erased_serialize_f32(&mut self, f32) -> Result<Ok, Error>;
     fn erased_serialize_f64(&mut self, f64) -> Result<Ok, Error>;
     fn erased_serialize_char(&mut self, char) -> Result<Ok, Error>;
@@ -260,6 +269,14 @@ impl<T> Serializer for erase::Serializer<T> where T: serde::Serializer {
     }
     fn erased_serialize_u64(&mut self, v: u64) -> Result<Ok, Error> {
         self.take().serialize_u64(v).map(Ok::new).map_err(erase)
+    }
+    serde_if_integer128! {
+        fn erased_serialize_i128(&mut self, v: i128) -> Result<Ok, Error> {
+            self.take().serialize_i128(v).map(Ok::new).map_err(erase)
+        }
+        fn erased_serialize_u128(&mut self, v: u128) -> Result<Ok, Error> {
+            self.take().serialize_u128(v).map(Ok::new).map_err(erase)
+        }
     }
     fn erased_serialize_f32(&mut self, v: f32) -> Result<Ok, Error> {
         self.take().serialize_f32(v).map(Ok::new).map_err(erase)
@@ -410,6 +427,14 @@ macro_rules! impl_serializer_for_trait_object {
             }
             fn serialize_u64(self, v: u64) -> Result<Ok, Error> {
                 self.erased_serialize_u64(v)
+            }
+            serde_if_integer128! {
+                fn serialize_i128(self, v: i128) -> Result<Ok, Error> {
+                    self.erased_serialize_i128(v)
+                }
+                fn serialize_u128(self, v: u128) -> Result<Ok, Error> {
+                    self.erased_serialize_u128(v)
+                }
             }
             fn serialize_f32(self, v: f32) -> Result<Ok, Error> {
                 self.erased_serialize_f32(v)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -113,13 +113,8 @@ pub trait Serializer {
     fn erased_serialize_u32(&mut self, u32) -> Result<Ok, Error>;
     fn erased_serialize_u64(&mut self, u64) -> Result<Ok, Error>;
     serde_if_integer128! {
-        fn erased_serialize_i128(&mut self, i128) -> Result<Ok, Error> {
-            Err(<Error as serde::ser::Error>::custom("erased I128 is not supported"))
-        }
-
-        fn erased_serialize_u128(&mut self, u128) -> Result<Ok, Error> {
-            Err(<Error as serde::ser::Error>::custom("erased U128 is not supported"))
-        }
+        fn erased_serialize_i128(&mut self, i128) -> Result<Ok, Error>;
+        fn erased_serialize_u128(&mut self, u128) -> Result<Ok, Error>;
     }
     fn erased_serialize_f32(&mut self, f32) -> Result<Ok, Error>;
     fn erased_serialize_f64(&mut self, f64) -> Result<Ok, Error>;
@@ -781,6 +776,14 @@ macro_rules! deref_erased_serializer {
             }
             fn erased_serialize_u64(&mut self, v: u64) -> Result<Ok, Error> {
                 (**self).erased_serialize_u64(v)
+            }
+            serde_if_integer128! {
+                fn erased_serialize_i128(&mut self, v: i128) -> Result<Ok, Error> {
+                    (**self).erased_serialize_i128(v)
+                }
+                fn erased_serialize_u128(&mut self, v: u128) -> Result<Ok, Error> {
+                    (**self).erased_serialize_u128(v)
+                }
             }
             fn erased_serialize_f32(&mut self, v: f32) -> Result<Ok, Error> {
                 (**self).erased_serialize_f32(v)


### PR DESCRIPTION
Hi there!

I ran into a case recently where I needed 128bit number support in `erased-serde` so have taken a stab at implementing it here.

I've gone with a conservative route of defaulting the conditional trait methods even though I think the `de::Visitor` is actually private. This _should_ be a non-breaking change.

Please let me know if you'd like me to throw a test case in there somewhere or if there's anything you'd like done differently.