### PR TITLE
Delete deprecated Error::description implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,11 +17,7 @@ impl Display for Error {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        &self.msg
-    }
-}
+impl std::error::Error for Error {}
 
 #[cfg(not(feature = "std"))]
 impl serde::ser::StdError for Error {}


### PR DESCRIPTION
This has been unnecessary to implement since rust 1.27 and deprecated to call since rust 1.42.