### PR TITLE
Allow the erased `Serialize` trait to report the type name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = ["std"]
 std = ["serde/std"]
 alloc = ["serde/alloc"] # requires Rust 1.36+
 unstable-debug = []
+type_name = []
 
 [[test]]
 name = "test"


### PR DESCRIPTION
After https://github.com/dtolnay/serde-yaml/pull/234, I decided to write my own serde serializer/deserializer to accomplish what I wanted regarding text serialization with comments, blocks and alternate integer bases.  [Serde-annotate](https://github.com/lowRISC/serde-annotate/) allows one to emit such documents in a variety of formats and includes a very permissive parser that accepts most of the json extensions that I know of.

I would like to make serde-annotate work correctly with erased-serde as well, as I have a use case where number of different functions return their serializable result struct as a `erased_serde::Serialize` trait object.  I must admit a lack of expertise here, but having erased_serde make some type information available to the serializer was the only solution I could find (See https://github.com/lowRISC/serde-annotate/pull/3 for the list of things I tried).

I need to take another look at your autoref-specialization case study document and see if I can make that work (I failed in my first attempt, but I think I need to try again).

I also saw your [Pre-RFC: non-footgun non-static TypeId](https://internals.rust-lang.org/t/pre-rfc-non-footgun-non-static-typeid/17079) and I would work up a solution using something like `same_as`.

This PR represents my current solution.  I'd like to find the **right** solution.