### PR TITLE
Generalize impls for `&mut dyn` to more lifetime variables

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -773,7 +773,7 @@ where
 
 // IMPL SERDE FOR ERASED SERDE /////////////////////////////////////////////////
 
-impl<'de, 'a> serde::de::DeserializeSeed<'de> for &'a mut dyn DeserializeSeed<'de> {
+impl<'de> serde::de::DeserializeSeed<'de> for &mut (dyn DeserializeSeed<'de> + '_) {
     type Value = Out;
     fn deserialize<D>(self, deserializer: D) -> Result<Out, D::Error>
     where
@@ -953,16 +953,16 @@ macro_rules! impl_deserializer_for_trait_object {
     };
 }
 
-impl_deserializer_for_trait_object!({'de, 'a} {} &'a mut dyn Deserializer<'de>);
-impl_deserializer_for_trait_object!({'de, 'a} {} &'a mut (dyn Deserializer<'de> + Send));
-impl_deserializer_for_trait_object!({'de, 'a} {} &'a mut (dyn Deserializer<'de> + Sync));
-impl_deserializer_for_trait_object!({'de, 'a} {} &'a mut (dyn Deserializer<'de> + Send + Sync));
+impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + '_));
+impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Send + '_));
+impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Sync + '_));
+impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Send + Sync + '_));
 impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de>>);
 impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send>);
 impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Sync>);
 impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send + Sync>);
 
-impl<'de, 'a> serde::de::Visitor<'de> for &'a mut dyn Visitor<'de> {
+impl<'de> serde::de::Visitor<'de> for &mut (dyn Visitor<'de> + '_) {
     type Value = Out;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -1171,7 +1171,7 @@ impl<'de, 'a> serde::de::Visitor<'de> for &'a mut dyn Visitor<'de> {
     }
 }
 
-impl<'de, 'a> serde::de::SeqAccess<'de> for &'a mut dyn SeqAccess<'de> {
+impl<'de> serde::de::SeqAccess<'de> for &mut (dyn SeqAccess<'de> + '_) {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
@@ -1191,7 +1191,7 @@ impl<'de, 'a> serde::de::SeqAccess<'de> for &'a mut dyn SeqAccess<'de> {
     }
 }
 
-impl<'de, 'a> serde::de::MapAccess<'de> for &'a mut dyn MapAccess<'de> {
+impl<'de> serde::de::MapAccess<'de> for &mut (dyn MapAccess<'de> + '_) {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
@@ -1223,7 +1223,7 @@ impl<'de, 'a> serde::de::MapAccess<'de> for &'a mut dyn MapAccess<'de> {
     }
 }
 
-impl<'de, 'a> serde::de::EnumAccess<'de> for &'a mut dyn EnumAccess<'de> {
+impl<'de> serde::de::EnumAccess<'de> for &mut (dyn EnumAccess<'de> + '_) {
     type Error = Error;
     type Variant = Variant<'de>;
 


### PR DESCRIPTION
These 9 impls were overly restrictive as written.

When you write `for &'a mut dyn Trait`, rustc silently desugars this to `for &'a mut (dyn Trait + 'a)`. This is almost never an issue, but in some situations can cause extremely confusing lifetime errors such as the following.

```rust
fn assert_is_deserializer<'de, D: serde::Deserializer<'de>>(_deserializer: D) {}

fn do_thing<'a, 'de>(mut deserializer: Box<dyn erased_serde::Deserializer<'de> + 'a>) {
    assert_is_deserializer(&mut *deserializer);
}
```

```console
error: lifetime may not live long enough
 --> src/main.rs:4:5
  |
3 | fn do_thing<'a, 'de>(mut deserializer: Box<dyn erased_serde::Deserializer<'de> + 'a>) {
  |             --  --- lifetime `'de` defined here
  |             |
  |             lifetime `'a` defined here
4 |     assert_is_deserializer(&mut *deserializer);
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'de` must outlive `'a`
  |
  = help: consider adding the following bound: `'de: 'a`
  = note: requirement occurs because of a mutable reference to `dyn erased_serde::Deserializer<'_>`
  = note: mutable references are invariant over their type parameter
  = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

error[E0597]: `*deserializer` does not live long enough
 --> src/main.rs:4:28
  |
3 | fn do_thing<'a, 'de>(mut deserializer: Box<dyn erased_serde::Deserializer<'de> + 'a>) {
  |             --       ---------------- binding `deserializer` declared here
  |             |
  |             lifetime `'a` defined here
4 |     assert_is_deserializer(&mut *deserializer);
  |     -----------------------^^^^^^^^^^^^^^^^^^-
  |     |                      |
  |     |                      borrowed value does not live long enough
  |     argument requires that `*deserializer` is borrowed for `'a`
5 | }
  | - `*deserializer` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
```

Here, rustc is saying that `&mut *deserializer`, which is of type `&mut dyn erased_serde::Deserializer<'de>`, does not implement `serde::Deserializer<'de>`, even though erased-serde contains an `impl<'de, 'a> serde::Deserializer<'de> for &'a mut dyn Deserializer<'de>`.

But in fact the impl that erased-serde contains is for `&'a mut (dyn Deserializer<'de> + 'a)`, whereas the impl needed is `&'b mut (dyn Deserializer<'de> + 'a)`. The user just needed to cast from one to the other to make the error go away:

```rust
assert_is_deserializer(&mut *deserializer as &mut dyn erased_serde::Deserializer<'de>);
```

This PR makes the cast unneeded.