### PR TITLE
Generalize Box impls to more lifetime variables

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -957,10 +957,10 @@ impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + '_));
 impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Send + '_));
 impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Sync + '_));
 impl_deserializer_for_trait_object!({'de} {} &mut (dyn Deserializer<'de> + Send + Sync + '_));
-impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de>>);
-impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send>);
-impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Sync>);
-impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send + Sync>);
+impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + '_>);
+impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send + '_>);
+impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Sync + '_>);
+impl_deserializer_for_trait_object!({'de} {mut} Box<dyn Deserializer<'de> + Send + Sync + '_>);
 
 impl<'de> serde::de::Visitor<'de> for &mut (dyn Visitor<'de> + '_) {
     type Value = Out;


### PR DESCRIPTION
Much like #71. This fixes the following code.

```rust
fn assert_is_deserializer<'de, D: serde::Deserializer<'de>>(_deserializer: D) {}

fn do_thing<'a, 'de>(deserializer: Box<dyn erased_serde::Deserializer<'de> + 'a>) {
    assert_is_deserializer(deserializer);
}
```

Lifetime error before this PR:

```console
error[E0521]: borrowed data escapes outside of function
 --> src/main.rs:4:5
  |
3 | fn do_thing<'a, 'de>(deserializer: Box<dyn erased_serde::Deserializer<'de> + 'a>) {
  |             --       ------------ `deserializer` is a reference that is only valid in the function body
  |             |
  |             lifetime `'a` defined here
4 |     assert_is_deserializer(deserializer);
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |     |
  |     `deserializer` escapes the function body here
  |     argument requires that `'a` must outlive `'static`

For more information about this error, try `rustc --explain E0521`.
```

You would previously have needed to write `assert_is_deserializer(&mut *deserializer)` in order to obtain something with a valid serde Deserializer impl. The new impl in this PR is equivalent to performing that reborrow at the top of every Deserializer method call.