### PR TITLE
Generalize even more impls

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -800,10 +800,10 @@ macro_rules! impl_serializer_for_trait_object {
     };
 }
 
-impl_serializer_for_trait_object!(&'a mut dyn Serializer);
-impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Send));
-impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Sync));
-impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Send + Sync));
+impl_serializer_for_trait_object!(&'a mut (dyn Serializer + '_));
+impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Send + '_));
+impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Sync + '_));
+impl_serializer_for_trait_object!(&'a mut (dyn Serializer + Send + Sync + '_));
 
 pub struct Seq<'a> {
     data: Any,


### PR DESCRIPTION
This PR is the serialization equivalent of the deserialization impl changes in #71.

```rust
fn assert_is_serializer<S: serde::Serializer>(_serializer: S) {}

fn do_thing(mut serializer: Box<dyn erased_serde::Serializer>) {
    assert_is_serializer(&mut *serializer);
}
```

```console
error[E0597]: `*serializer` does not live long enough
 --> src/main.rs:4:26
  |
3 | fn do_thing(mut serializer: Box<dyn erased_serde::Serializer>) {
  |             -------------- binding `serializer` declared here
4 |     assert_is_serializer(&mut *serializer);
  |     ---------------------^^^^^^^^^^^^^^^^-
  |     |                    |
  |     |                    borrowed value does not live long enough
  |     argument requires that `*serializer` is borrowed for `'static`
5 | }
  | - `*serializer` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
```

