### PR TITLE
Seal public traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ mod de;
 mod error;
 mod features_check;
 mod map;
+mod sealed;
 mod ser;
 
 pub use crate::de::{deserialize, Deserializer};

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,0 +1,11 @@
+pub mod serialize {
+    pub trait Sealed {}
+}
+
+pub mod serializer {
+    pub trait Sealed {}
+}
+
+pub mod deserializer {
+    pub trait Sealed {}
+}


### PR DESCRIPTION
None of these are meant to have been directly implemented. You implement `serde::Serialize` and get `erased_serde::Serialize` via the blanket impl.