### PR TITLE
Return impl Trait from `erase` functions

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -252,7 +252,7 @@ impl<'de> dyn Deserializer<'de> {
     ///     println!("{}", data["A"] + data["B"]);
     /// }
     /// ```
-    pub fn erase<D>(deserializer: D) -> erase::Deserializer<D>
+    pub fn erase<D>(deserializer: D) -> impl Deserializer<'de>
     where
         D: serde::Deserializer<'de>,
     {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -211,7 +211,7 @@ impl dyn Serializer {
     ///     value.erased_serialize(format).unwrap();
     /// }
     /// ```
-    pub fn erase<S>(serializer: S) -> erase::Serializer<S>
+    pub fn erase<S>(serializer: S) -> impl Serializer
     where
         S: serde::Serializer,
         S::Ok: 'static,


### PR DESCRIPTION
The only thing one is allowed to do with these return values is treat them as an implementation of the corresponding erased-serde trait.