### PR TITLE
Remove 'static constraint on S::Ok

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -214,7 +214,6 @@ impl dyn Serializer {
     pub fn erase<S>(serializer: S) -> impl Serializer
     where
         S: serde::Serializer,
-        S::Ok: 'static,
     {
         erase::Serializer::new(serializer)
     }


### PR DESCRIPTION
As of the refactor in #93, this is no longer needed for soundness.