### PR TITLE
Handle the case where a Serialize fails without calling the Serializer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -243,6 +243,6 @@ impl serde::ser::StdError for ShortCircuit {}
 
 impl serde::ser::Error for ShortCircuit {
     fn custom<T: Display>(_msg: T) -> Self {
-        unreachable!()
+        ShortCircuit {}
     }
 }


### PR DESCRIPTION
Hey! :wave:

Upgrading to `0.4` I found if a `Serialize` itself fails without ever calling the given `Serializer` then we'll hit an `unreachable!()`. I've got a repro as a test case in this PR. The solution I've got here is to return a generic message suggesting the value itself failed. That may not be ideal since it loses the original error, but is still better than panicking.

Is there any better way this could be handled?