### PR TITLE
Make `Serialize*` traits public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,10 @@ mod ser;
 
 pub use crate::de::{deserialize, Deserializer};
 pub use crate::error::{Error, Result};
-pub use crate::ser::{serialize, Serialize, Serializer};
+pub use crate::ser::{
+    serialize, Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant,
+    SerializeTuple, SerializeTupleStruct, SerializeTupleVariant, Serializer,
+};
 
 // Not public API.
 #[doc(hidden)]


### PR DESCRIPTION
I am working on a library that I would like the library to remain format-agnostic. To do this I am using `erased-serde` to "inject" the format at runtime as a `&mut dyn Serializer`.

In my library the user defines a schema which looks something like this and the `resolve` function would be implemented by them:
```rust
pub struct Schema {
   types: Vec<Type>
}

pub struct Type {
   name: Cow<'static, str>,
   resolve: Box<dyn Fn(Serializer)> // `Serializer` is shown in the next code snippet
}
```

As discussed in #39 `erased-serde` isn't something that should be in the public API so I am wrapping all of its types. This also has the added side-effect that I can require `self` instead of `&mut self` for extra type safety.

An example of what I am doing is below.
```rust
pub struct Serializer<'a>(&'a mut dyn erased_serde::Serializer);

impl<'a> Serializer<'a> {
    pub fn serialize_bool(self, value: bool) {
        self.0.erased_serialize_bool(value)
    }
    
    // ...
}
```

However, right now I can only deal with primitive types as `SerializeMap` and similar types are private. This PR makes them public so the following code would compile.
 ```rust
pub struct SerializeMap<'a>(&'a mut dyn erased_serde::SerializeMap);
```