### PR TITLE
Exposed typed result for ser::erased::Serializer<S>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod ser;
 
 pub use crate::de::{deserialize, Deserializer};
 pub use crate::error::{Error, Result};
-pub use crate::ser::{serialize, Serialize, Serializer};
+pub use crate::ser::{convert_ser_error, serialize, Serialize, Serializer};
 
 // Not public API.
 #[doc(hidden)]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -287,6 +287,15 @@ mod erase {
                 _ => unreachable!(),
             }
         }
+
+        /// Takes the stored result of the erased serializer after serializing.
+        pub fn result(self) -> Result<S::Ok, S::Error> {
+            match self {
+                 Serializer::Complete(ok) => Ok(ok),
+                 Serializer::Error(err) => Err(err),
+                 _ => panic!("Tried to take result of serializer before serializing or finished serializing an object.")
+            }
+        }
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -697,6 +697,16 @@ where
     }
 }
 
+/// Converts the result from a Serializer::erase_xxx function into a public-api result.
+pub fn convert_ser_error(err: ErrorImpl) -> crate::Error {
+    match err {
+        ErrorImpl::ShortCircuit => {
+            serde::ser::Error::custom("Call `serializer::result()` to find out the error.")
+        }
+        ErrorImpl::Custom(msg) => serde::ser::Error::custom(msg),
+    }
+}
+
 serialize_trait_object!(Serialize);
 
 struct MakeSerializer<TraitObject>(TraitObject);


### PR DESCRIPTION
Fixes #113. This implements the proposed solution of having a `result()` function in the concrete type returned by `<dyn erased_serde::Serializer>::erase`.